### PR TITLE
fix(ci): replace guardian-test with codex-review reusable workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,11 +1,13 @@
-name: Codex Guardian PR Review
+name: Codex PR Review
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  guardian:
-    uses: digar011/guardian-test/.github/workflows/codex-guardian.yml@main
+  codex:
+    name: Generate Codex review
+    uses: digar011/codexium-guardian-template/.github/workflows/codex-review.yml@main
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+


### PR DESCRIPTION
Fixes broken reusable workflow reference in pr-review.yml.

- Replaces invalid guardian-test workflow call
- Aligns PR review with codex-review reusable workflow
- Unblocks required "Codex PR Review / Generate Codex review" check

No behavior changes outside CI.
