### PR TITLE
Fix newline escaping for workflow outputs

### DIFF
--- a/.github/workflows/codex-generator.yml
+++ b/.github/workflows/codex-generator.yml
@@ -315,8 +315,8 @@ jobs:
               
               # Output
               with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-                  f.write(f"branch_name={branch_name}\\n")
-                  f.write(f"files_created={','.join(files_created)}\\n")
+                  f.write(f"branch_name={branch_name}\n")
+                  f.write(f"files_created={','.join(files_created)}\n")
               
               print(f"\\n🎉 Generated {len(files_created)} files successfully!")
               
@@ -395,6 +395,5 @@ jobs:
   # =================================================
   # Neo V4 will automatically trigger via pull_request event
   # No manual trigger needed - neo-orchestrator.yml handles it
-
 
 


### PR DESCRIPTION
### Motivation
- Fix a bug in the `Generate code files` step where outputs written to `GITHUB_OUTPUT` used literal `\n` sequences causing `branch_name` to include the `files_created` line. 
- Ensure workflow outputs use real newline characters so `branch_name` and `files_created` are reported as separate outputs.

### Description
- Updated `.github/workflows/codex-generator.yml` inside the Python heredoc of the `Generate code files` step to correct output formatting. 
- Replaced `f.write(f"branch_name={branch_name}\\n")` with `f.write(f"branch_name={branch_name}\n")` and `f.write(f"files_created={','.join(files_created)}\\n")` with `f.write(f"files_created={','.join(files_created)}\n")`.
- Left all other `\\n` instances unchanged to preserve markdown content formatting.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952448781808333b30801783233c416)