### PR TITLE
docs: add required project documentation per Codexium standards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Codexium Guardian Template -- Environment Variables
+#
+# NOTE: This project runs on GitHub Actions. The primary secret (OPENAI_API_KEY)
+# should be added as a GitHub Actions repository secret, NOT in a .env file.
+#
+# This file documents the required variables for reference only.
+
+# OpenAI API Key (required) -- add this as a GitHub Actions secret
+# Settings > Secrets and variables > Actions > New repository secret
+OPENAI_API_KEY=sk-your-openai-api-key-here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Initial repository standardization (ONBOARDING.md, PRODUCT.md, CHANGELOG.md, TODO.md, CLAUDE.md)
+
+## [1.0.0] - 2025-12-30
+
+### Added
+- Codexium V4 Generator workflow for AI-powered code generation
+- Neo V4 Reviewer with 16 specialized review agents
+- Multi-layer guardrail system with configurable safety rules
+- Automatic PR creation from code generation requests
+- Gate enforcement to block merges on critical issues
+- Degraded mode for review resilience when agents fail
+- Memory system to prevent duplicate reviews
+- Cost estimation and spending controls
+- Telemetry and metrics tracking
+- Sample React/TypeScript components (Button, Hello, Login, SearchBar) with tests
+- Comprehensive documentation (usage guide, architecture, agent schemas, failure recovery, installation guide)
+- Comment-based trigger workflow
+- Codex materializer workflow for optional MCP integration
+- Unified guardrails configuration (codex-unified-guardrails.yml)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md -- Codexium Guardian Template
+
+## Project Overview
+
+This is the Codexium V4 + Neo V4 AI Development Automation System. It is a GitHub Template repository that provides AI-powered code generation (Codexium V4) and multi-agent code review (Neo V4) via GitHub Actions.
+
+**GitHub:** https://github.com/digar011/codexium-guardian-template.git
+
+## Tech Stack
+
+- **Platform:** GitHub Actions (CI/CD workflows)
+- **AI Provider:** OpenAI GPT models
+- **Scripts:** Python (call_openai.py, telemetry.py)
+- **Sample Code:** React 18, TypeScript (strict mode), Tailwind CSS, shadcn/ui, Vitest
+- **Configuration:** YAML (workflows, guardrails)
+
+## Key Directories
+
+- `.github/workflows/` -- Workflow definitions (codex-generator, neo-orchestrator, codex-guardian, codex-materialize, codex-comment-trigger)
+- `.github/scripts/neo/agents/` -- 16 agent instruction files (role_*_instruction.txt)
+- `.github/scripts/config/` -- Guardrails and safety configuration
+- `src/components/` -- Sample React/TypeScript components with co-located tests
+- `docs/` -- System documentation
+
+## Coding Standards
+
+- Use functional React components with hooks
+- Export default for components
+- All components must have a TypeScript props interface
+- Include data-testid attributes for testing
+- Tests go in co-located `*.test.tsx` files
+- Use Tailwind utility classes exclusively (no custom CSS)
+- Follow shadcn/ui component patterns
+- Minimum 80% test coverage target
+
+## Agent Instruction Files
+
+Agent instructions are plain-text files in `.github/scripts/neo/agents/`. Each contains natural language instructions for a specialized review domain. When editing these files:
+- Keep instructions clear and actionable
+- Specify what to flag vs. what to suggest
+- Include severity guidance (info, warn, error, critical)
+- Do not include API keys or secrets in instruction files
+
+## Secrets and Security
+
+- The only required secret is `OPENAI_API_KEY` (stored as a GitHub Actions secret, never committed)
+- Guardrails in `codex-unified-guardrails.yml` block dangerous patterns (DROP TABLE, hardcoded credentials, etc.)
+- Never commit API keys, tokens, or credentials to the repository
+
+## Testing
+
+- Sample components use Vitest for unit tests
+- Tests are co-located with components (e.g., `Button.tsx` / `Button.test.tsx`)
+- Test user interactions and edge cases
+
+## Build and Run
+
+This is primarily a GitHub Actions template -- there is no traditional "run" step. To test locally:
+- Python scripts can be tested with Python 3.8+
+- Sample React components can be tested with `npx vitest` (if a test runner is configured)
+
+## Common Pitfalls
+
+- Forgetting to add `OPENAI_API_KEY` as a GitHub secret will cause all workflows to fail
+- Editing workflow YAML syntax incorrectly will silently break pipelines -- validate YAML before committing
+- Agent instruction files are read as plain text; formatting matters for AI comprehension

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,133 @@
+# Onboarding Guide -- Codexium Guardian Template
+
+Welcome to the Codexium V4 + Neo V4 AI Development Automation System. This guide will get you productive as quickly as possible.
+
+## What This Project Is
+
+Codexium Guardian Template is an enterprise-grade GitHub Actions-based system that:
+- **Generates production-ready code** via AI (Codexium V4 Generator)
+- **Reviews all code automatically** via 16 specialized AI agents (Neo V4 Reviewer)
+
+It is designed as a GitHub Template repository -- teams clone it to add AI-powered code generation and review to any project.
+
+## Prerequisites
+
+- A GitHub account with repository admin access
+- An OpenAI API key (starts with `sk-`)
+- Basic familiarity with GitHub Actions
+- (Optional) Python 3.8+ for local script testing
+
+## First-Day Setup
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/digar011/codexium-guardian-template.git
+cd codexium-guardian-template
+```
+
+### 2. Add Your OpenAI API Key
+
+Go to your GitHub repo: **Settings > Secrets and variables > Actions > New repository secret**
+
+- **Name:** `OPENAI_API_KEY`
+- **Value:** Your OpenAI API key
+
+### 3. Understand the Directory Structure
+
+```
+codexium-guardian-template/
+  .github/
+    workflows/          -- GitHub Actions workflow definitions
+      codex-generator.yml       -- Triggers AI code generation
+      neo-orchestrator.yml      -- Orchestrates the 16-agent review
+      codex-guardian.yml        -- Individual agent executor
+      codex-materialize.yml     -- (Optional) MCP integration
+      codex-comment-trigger.yml -- Comment-based triggers
+    scripts/
+      config/
+        codex-unified-guardrails.yml  -- Safety and cost rules
+        guardrails.yml                -- Legacy guardrails
+      neo/agents/       -- 16 agent instruction files (role_*_instruction.txt)
+      call_openai.py    -- OpenAI API interface
+      telemetry.py      -- Metrics and logging
+  src/components/       -- Sample React/TypeScript components with tests
+  docs/                 -- Full system documentation
+```
+
+### 4. Run Your First Code Generation
+
+1. Go to the **Actions** tab in GitHub
+2. Select **Codexium V4 Generator**
+3. Click **Run workflow**
+4. Enter a prompt like: `Create a card component with TypeScript and Tailwind CSS`
+5. Codexium generates code, opens a PR, and Neo reviews it automatically
+
+### 5. Run Your First Code Review
+
+1. Create a feature branch, make a code change, and open a PR
+2. Neo V4 automatically selects relevant agents based on file types
+3. Review the feedback posted as PR comments
+
+## Key Concepts
+
+### The 16 Review Agents
+
+Each agent specializes in a domain. They are defined in `.github/scripts/neo/agents/`:
+
+| Agent | File | Focus |
+|-------|------|-------|
+| General | `role_general_instruction.txt` | Core code quality |
+| Security | `role_security_instruction.txt` | Vulnerabilities, secrets |
+| QA | `role_qa_instruction.txt` | Test coverage |
+| UI/UX | `role_ui_ux_instruction.txt` | Design, usability |
+| Performance | `role_performance_instruction.txt` | Speed, optimization |
+| SEO | `role_seo_instruction.txt` | Search visibility |
+| Architecture | `role_architect_instruction.txt` | Design patterns |
+| Critical Analysis | `role_critic_instruction.txt` | Deep review |
+| DevOps | `role_devops_instruction.txt` | CI/CD, deployment |
+| Compliance | `role_compliance_instruction.txt` | GDPR, HIPAA |
+| i18n | `role_i18n_instruction.txt` | Internationalization |
+| Accessibility | `role_a11y_instruction.txt` | WCAG compliance |
+| Documentation | `role_documentation_instruction.txt` | API docs |
+| Conversion | `role_conversion_instruction.txt` | CRO, revenue |
+| Privacy | `role_privacy_instruction.txt` | Data protection |
+| n8n | `role_n8n_instruction.txt` | Workflow automation |
+
+### Guardrails
+
+Safety rules are defined in `.github/scripts/config/codex-unified-guardrails.yml`. They control:
+- Confidence thresholds for auto-generation
+- Blocked patterns (DROP TABLE, hardcoded secrets, etc.)
+- Cost limits per request
+
+### Gate Enforcement
+
+Neo can block a merge if critical issues are found. The gate system uses severity levels: `info`, `warn`, `error`, `critical`.
+
+## Common Tasks
+
+### Customize an Agent
+
+Edit the relevant `role_*_instruction.txt` file. Each file contains natural language instructions that tell the AI agent what to look for.
+
+### Adjust Cost Limits
+
+Edit `.github/scripts/config/codex-unified-guardrails.yml`:
+```yaml
+cost_limits:
+  max_per_request: 1.00
+  warn_threshold: 0.25
+```
+
+### Add a New Agent
+
+1. Create `role_yourname_instruction.txt` in `.github/scripts/neo/agents/`
+2. Define the agent's specialty and review criteria
+3. Update `neo-orchestrator.yml` to include the new agent
+
+## Where to Get Help
+
+- **Docs:** See the `docs/` directory for full documentation
+- **Issues:** Open an issue on GitHub for bugs or feature requests
+- **Architecture:** Read `ARCHITECTURE.md` for system design overview

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,88 @@
+# Product Overview -- Codexium Guardian Template
+
+## Product Name
+
+Codexium V4 + Neo V4 AI Development Automation System
+
+## Description
+
+Codexium Guardian Template is an enterprise-grade, open-source GitHub Template repository that integrates AI-powered code generation and code review directly into any GitHub-based development workflow. It consists of two tightly integrated subsystems:
+
+1. **Codexium V4 Generator** -- An AI code generation engine that creates production-ready code from natural language prompts, complete with tests, types, and documentation.
+2. **Neo V4 Reviewer** -- A multi-agent AI code review system with 16 specialized agents that automatically review every pull request for security, quality, performance, accessibility, compliance, and more.
+
+## Target Audience
+
+- Development teams that want AI-assisted code generation with built-in quality gates
+- Organizations that need automated, multi-dimensional code review
+- Teams adopting AI development tools while maintaining security and quality standards
+- Solo developers who want enterprise-grade review coverage
+
+## Core Features
+
+### Code Generation (Codexium V4)
+- Natural language to production code via GitHub Actions
+- Supports React, Vue, Node.js, Python, SQL, Docker, and more
+- Safety evaluation and confidence scoring before generation
+- Automatic pull request creation with generated code
+- Cost estimation and spending controls
+
+### Code Review (Neo V4)
+- 16 specialized AI review agents covering security, QA, UI/UX, performance, SEO, architecture, DevOps, compliance, i18n, accessibility, documentation, conversion, privacy, and workflow automation
+- Automatic agent selection based on files changed in the PR
+- Gate enforcement that can block merges for critical issues
+- Degraded mode -- review continues even if individual agents fail
+- Memory system to prevent duplicate reviews
+
+### Safety and Quality
+- Multi-layer guardrails block dangerous operations (DROP TABLE, hardcoded secrets, command injection)
+- Configurable confidence thresholds and cost limits
+- Human approval always required as the final step
+
+## Technical Specifications
+
+| Attribute | Value |
+|-----------|-------|
+| Platform | GitHub Actions |
+| AI Provider | OpenAI (GPT models) |
+| Languages Supported | TypeScript, JavaScript, Python, SQL, Docker, and more |
+| Number of Review Agents | 16 |
+| Typical Generation Time | 90 seconds to 5 minutes |
+| Typical Cost per Request | $0.02 to $1.00 |
+| Required Secret | `OPENAI_API_KEY` |
+| License | MIT |
+
+## Architecture Summary
+
+```
+User Request --> Codexium V4 Evaluates (confidence scoring)
+             --> Codexium V4 Generates (code + tests + docs)
+             --> PR Created Automatically
+             --> Neo V4 Reviews (16 agents in parallel)
+             --> Gate Decision (pass / warn / block)
+             --> Human Decision (merge / request changes / close)
+```
+
+## Repository Structure
+
+- `.github/workflows/` -- GitHub Actions workflow definitions
+- `.github/scripts/neo/agents/` -- 16 agent instruction files
+- `.github/scripts/config/` -- Guardrails and safety configuration
+- `.github/scripts/call_openai.py` -- OpenAI API interface
+- `.github/scripts/telemetry.py` -- Metrics and logging
+- `src/components/` -- Sample React/TypeScript components with tests
+- `docs/` -- Full system documentation (usage guide, architecture, schemas, failure recovery)
+
+## Roadmap Considerations
+
+- Persistence layer for long-term data storage and analysis (not yet implemented)
+- Expanded operational safety measures
+- Additional agent types based on team feedback
+- Multi-repo centralized configuration support
+
+## Success Metrics
+
+- Generation success rate: >95%
+- Review completion rate: 100%
+- Gate accuracy: >95%
+- Cost per generation within defined limits

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,32 @@
+# Task Queue -- Codexium Guardian Template
+
+## Queue (Planned)
+
+- [ ] Implement persistence layer for long-term data storage and analysis
+- [ ] Add support for multi-repo centralized configuration (config repo pattern)
+- [ ] Expand operational safety measures to cover additional edge cases
+- [ ] Add automated integration tests for workflow pipelines
+- [ ] Create agent performance benchmarking suite
+- [ ] Document agent customization best practices with examples
+- [ ] Add support for additional AI providers beyond OpenAI
+
+## In Progress
+
+(No tasks currently in progress)
+
+## Completed
+
+- [x] Codexium V4 Generator workflow -- AI code generation from prompts
+- [x] Neo V4 Reviewer -- 16 specialized review agents
+- [x] Multi-layer guardrail system with safety rules
+- [x] Automatic PR creation from generation requests
+- [x] Gate enforcement for merge blocking on critical issues
+- [x] Degraded mode for review resilience
+- [x] Memory system to prevent duplicate reviews
+- [x] Cost estimation and spending controls
+- [x] Telemetry and metrics tracking
+- [x] Sample components with tests (Button, Hello, Login, SearchBar)
+- [x] Comprehensive documentation suite
+- [x] Comment-based trigger workflow
+- [x] Codex materializer workflow
+- [x] Repository standardization (ONBOARDING.md, PRODUCT.md, CHANGELOG.md, TODO.md, CLAUDE.md)


### PR DESCRIPTION
## Summary
- Added **ONBOARDING.md** — developer guide (setup, directory structure, 16-agent table, key concepts, common tasks)
- Added **PRODUCT.md** — product overview (Codexium V4 Generator + Neo V4 Reviewer, target audience, technical specs, architecture, roadmap)
- Added **CHANGELOG.md** — initial v1.0.0 documenting all features
- Added **TODO.md** — 7 planned items (persistence layer, multi-repo config, etc.) + completed items
- Added **CLAUDE.md** — project-level standards (tech stack, key directories, coding conventions, secrets policy, common pitfalls)
- Added **.env.example** — documents OPENAI_API_KEY GitHub Actions secret

## Context
Standardizing all Codexium repos. Existing README.md (420 lines) was already comprehensive — left untouched.

## Checklist
- [x] Only documentation files added
- [x] All 6 required files present
- [x] Commit follows Conventional Commits format

## Test plan
- [ ] All markdown files render correctly on GitHub
- [ ] No source code or workflow YAML was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)